### PR TITLE
feat: optional AllowComments and AllowTrailingCommas parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,28 @@ func main() {
 	//  Child value is at line 2, column 11, and is set to 'secret'
 }
 ```
+
+## Options
+
+By default `Unmarshal` accepts strict [RFC 8259](https://datatracker.ietf.org/doc/html/rfc8259) JSON. You can pass options to accept common non-standard JSON dialects. Both options are opt-in, so the default behaviour is unchanged.
+
+- `AllowComments()` — allow `//` line comments and `/* ... */` block comments anywhere whitespace is permitted.
+- `AllowTrailingCommas()` — allow a single trailing comma before a closing `]` or `}`.
+
+These are handy for formats such as [JSONC](https://code.visualstudio.com/docs/languages/json#_json-with-comments), `tsconfig.json`, and Azure ARM/Bicep deployment templates, all of which permit comments.
+
+```golang
+input := []byte(`{
+	// the service to deploy
+	"name": "example",
+	"tags": [ "a", "b", ], /* trailing comma */
+}`)
+
+var target map[string]any
+if err := jfather.Unmarshal(input, &target,
+	jfather.AllowComments(),
+	jfather.AllowTrailingCommas(),
+); err != nil {
+	panic(err)
+}
+```

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,38 @@
+package jfather_test
+
+import (
+	"fmt"
+
+	"github.com/liamg/jfather"
+)
+
+func ExampleAllowComments() {
+	input := []byte(`{
+	// the service to deploy
+	"name": "example" /* block comment */
+}`)
+
+	var target struct {
+		Name string `json:"name"`
+	}
+	if err := jfather.Unmarshal(input, &target, jfather.AllowComments()); err != nil {
+		panic(err)
+	}
+
+	fmt.Println(target.Name)
+	// Output: example
+}
+
+func ExampleAllowTrailingCommas() {
+	input := []byte(`{ "tags": [ "a", "b", ], }`)
+
+	var target struct {
+		Tags []string `json:"tags"`
+	}
+	if err := jfather.Unmarshal(input, &target, jfather.AllowTrailingCommas()); err != nil {
+		panic(err)
+	}
+
+	fmt.Println(target.Tags)
+	// Output: [a b]
+}

--- a/options.go
+++ b/options.go
@@ -1,0 +1,20 @@
+package jfather
+
+// Option configures optional, non-standard parsing behaviour. All options
+// are off by default, so Unmarshal stays strict JSON unless a caller opts
+// in.
+type Option func(*parser)
+
+// AllowComments permits JavaScript-style comments — // to end of line and
+// /* ... */ block comments — anywhere whitespace is allowed. Standard
+// JSON forbids comments, but several dialects permit them (JSONC,
+// tsconfig, and ARM/Bicep deployment templates).
+func AllowComments() Option {
+	return func(p *parser) { p.allowComments = true }
+}
+
+// AllowTrailingCommas permits a single trailing comma before a closing
+// ']' or '}'. Standard JSON forbids it.
+func AllowTrailingCommas() Option {
+	return func(p *parser) { p.allowTrailingCommas = true }
+}

--- a/options_test.go
+++ b/options_test.go
@@ -1,0 +1,147 @@
+package jfather
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type optTarget struct {
+	Name    string   `json:"name"`
+	Balance float64  `json:"balance"`
+	Tags    []string `json:"tags"`
+}
+
+func Test_AllowComments_LineComments(t *testing.T) {
+	example := []byte(`{
+	// leading line comment
+	"name": "testing", // trailing line comment
+	"balance": 3.14
+	// comment before close
+}`)
+
+	var target optTarget
+	require.NoError(t, Unmarshal(example, &target, AllowComments()))
+	assert.Equal(t, "testing", target.Name)
+	assert.Equal(t, 3.14, target.Balance)
+}
+
+func Test_AllowComments_BlockComments(t *testing.T) {
+	example := []byte(`{
+	/* block before key */ "name": "testing",
+	"balance": /* inline */ 3.14,
+	/* multi
+	   line
+	   block */
+	"tags": [ "a", /* mid-array */ "b" ]
+}`)
+
+	var target optTarget
+	require.NoError(t, Unmarshal(example, &target, AllowComments()))
+	assert.Equal(t, "testing", target.Name)
+	assert.Equal(t, 3.14, target.Balance)
+	assert.Equal(t, []string{"a", "b"}, target.Tags)
+}
+
+func Test_AllowComments_DoesNotTouchStringContents(t *testing.T) {
+	// // and /* inside string values must be preserved verbatim.
+	example := []byte(`{ "name": "http://example.com/*not a comment*/" }`)
+
+	var target optTarget
+	require.NoError(t, Unmarshal(example, &target, AllowComments()))
+	assert.Equal(t, "http://example.com/*not a comment*/", target.Name)
+}
+
+func Test_Comments_RejectedByDefault(t *testing.T) {
+	example := []byte(`{ "name": "testing" // nope
+}`)
+	var target optTarget
+	assert.Error(t, Unmarshal(example, &target), "strict mode must reject comments")
+}
+
+func Test_AllowComments_UnterminatedBlock(t *testing.T) {
+	example := []byte(`{ "name": "testing" /* never closed `)
+	var target optTarget
+	err := Unmarshal(example, &target, AllowComments())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unterminated block comment")
+}
+
+func Test_AllowComments_LoneSlashIsError(t *testing.T) {
+	example := []byte(`{ "name": / "testing" }`)
+	var target optTarget
+	assert.Error(t, Unmarshal(example, &target, AllowComments()))
+}
+
+func Test_AllowTrailingCommas_Object(t *testing.T) {
+	example := []byte(`{
+	"name": "testing",
+	"balance": 3.14,
+}`)
+	var target optTarget
+	require.NoError(t, Unmarshal(example, &target, AllowTrailingCommas()))
+	assert.Equal(t, "testing", target.Name)
+	assert.Equal(t, 3.14, target.Balance)
+}
+
+func Test_AllowTrailingCommas_Array(t *testing.T) {
+	example := []byte(`{ "tags": [ "a", "b", ] }`)
+	var target optTarget
+	require.NoError(t, Unmarshal(example, &target, AllowTrailingCommas()))
+	assert.Equal(t, []string{"a", "b"}, target.Tags)
+}
+
+func Test_TrailingCommas_RejectedByDefault(t *testing.T) {
+	example := []byte(`{ "tags": [ "a", "b", ] }`)
+	var target optTarget
+	assert.Error(t, Unmarshal(example, &target), "strict mode must reject trailing commas")
+}
+
+func Test_Options_Combined(t *testing.T) {
+	// Comments and trailing commas together, mimicking a real ARM-style
+	// document.
+	example := []byte(`{
+	// resource config
+	"name": "testing",
+	"tags": [
+		"a", // first
+		"b", /* last */
+	],
+	"balance": 3.14,
+}`)
+	var target optTarget
+	require.NoError(t, Unmarshal(example, &target, AllowComments(), AllowTrailingCommas()))
+	assert.Equal(t, "testing", target.Name)
+	assert.Equal(t, []string{"a", "b"}, target.Tags)
+	assert.Equal(t, 3.14, target.Balance)
+}
+
+// Metadata (line/column) must stay correct after a multi-line block
+// comment shifts subsequent tokens down.
+func Test_AllowComments_PreservesMetadataAfterBlock(t *testing.T) {
+	example := []byte("{\n/* a\nb */\n\"name\": \"testing\"\n}")
+
+	var meta metaObject
+	require.NoError(t, Unmarshal(example, &meta, AllowComments()))
+	// "name" sits on line 4 after the 3-line block comment.
+	assert.Equal(t, 4, meta.nameLine, "line number must account for newlines inside the block comment")
+}
+
+type metaObject struct {
+	nameLine int
+}
+
+func (m *metaObject) UnmarshalJSONWithMetadata(node Node) error {
+	content := node.Content()
+	for i := 0; i+1 < len(content); i += 2 {
+		var key string
+		if err := content[i].Decode(&key); err != nil {
+			return err
+		}
+		if key == "name" {
+			m.nameLine = content[i+1].Range().Start.Line
+		}
+	}
+	return nil
+}

--- a/parse.go
+++ b/parse.go
@@ -2,19 +2,26 @@ package jfather
 
 import (
 	"fmt"
+	"io"
 )
 
 type parser struct {
-	peeker   *PeekReader
-	position Position
-	size     int
+	peeker              *PeekReader
+	position            Position
+	size                int
+	allowComments       bool
+	allowTrailingCommas bool
 }
 
-func newParser(p *PeekReader, pos Position) *parser {
-	return &parser{
+func newParser(p *PeekReader, pos Position, opts ...Option) *parser {
+	parser := &parser{
 		position: pos,
 		peeker:   p,
 	}
+	for _, opt := range opts {
+		opt(parser)
+	}
+	return parser
 }
 
 func (p *parser) parse() (Node, error) {
@@ -92,6 +99,64 @@ func (p *parser) newNode(k Kind) *node {
 	return &node{
 		start: p.position,
 		kind:  k,
+	}
+}
+
+// skipComment consumes a // line comment or /* block comment. It is
+// called from parseWhitespace when allowComments is set and the next rune
+// is '/'. A line comment stops at (but does not consume) the terminating
+// newline, leaving parseWhitespace to account for it. A '/' not followed
+// by '/' or '*' is malformed — comments are the only place '/' is legal
+// outside a string.
+func (p *parser) skipComment() error {
+	// consume the leading '/'
+	if _, err := p.next(); err != nil {
+		return err
+	}
+	c, err := p.next()
+	if err != nil {
+		return err
+	}
+
+	switch c {
+	case '/':
+		for {
+			b, err := p.peeker.Peek()
+			if err != nil {
+				if err == io.EOF {
+					return nil
+				}
+				return err
+			}
+			if b == 0x0a {
+				return nil
+			}
+			if _, err := p.next(); err != nil {
+				return err
+			}
+		}
+	case '*':
+		for {
+			b, err := p.next()
+			if err != nil {
+				if err == io.EOF {
+					return p.makeError("unterminated block comment")
+				}
+				return err
+			}
+			if b == 0x0a {
+				p.position.Column = 1
+				p.position.Line++
+				continue
+			}
+			if b == '*' {
+				if p.swallowIfEqual('/') {
+					return nil
+				}
+			}
+		}
+	default:
+		return p.makeError("unexpected character '%c' after '/'", c)
 	}
 }
 

--- a/parse_array.go
+++ b/parse_array.go
@@ -44,5 +44,17 @@ func (p *parser) parseArray() (Node, error) {
 		if !p.swallowIfEqual(',') {
 			return nil, p.makeError("unexpected character - expecting , or ]")
 		}
+
+		// A trailing comma is allowed to precede the closing ']' when the
+		// option is set.
+		if p.allowTrailingCommas {
+			if err := p.parseWhitespace(); err != nil {
+				return nil, err
+			}
+			if p.swallowIfEqual(']') {
+				n.end = p.position
+				return n, nil
+			}
+		}
 	}
 }

--- a/parse_object.go
+++ b/parse_object.go
@@ -60,6 +60,18 @@ func (p *parser) parseObject() (Node, error) {
 		if !p.swallowIfEqual(',') {
 			return nil, p.makeError("unexpected character - expecting , or }")
 		}
+
+		// A trailing comma is allowed to precede the closing '}' when the
+		// option is set.
+		if p.allowTrailingCommas {
+			if err := p.parseWhitespace(); err != nil {
+				return nil, err
+			}
+			if p.swallowIfEqual('}') {
+				n.end = p.position
+				return n, nil
+			}
+		}
 	}
 
 }

--- a/parse_whitespace.go
+++ b/parse_whitespace.go
@@ -20,6 +20,13 @@ func (p *parser) parseWhitespace() error {
 				p.position.Column = 1
 				p.position.Line++
 			}
+		case '/':
+			if !p.allowComments {
+				return nil
+			}
+			if err := p.skipComment(); err != nil {
+				return err
+			}
 		default:
 			return nil
 		}

--- a/unmarshal.go
+++ b/unmarshal.go
@@ -10,8 +10,11 @@ type Unmarshaler interface {
 
 // Unmarshal unmarshals the given JSON data into the target value.
 // It will attempt to use UnmarshalJSONWithMetadata if the target implements it, otherwise it will use the default json unmarshaler.
-func Unmarshal(data []byte, target any) error {
-	node, err := newParser(NewPeekReader(bytes.NewReader(data)), Position{1, 1}).parse()
+//
+// By default the input must be strict JSON. Pass options such as
+// AllowComments or AllowTrailingCommas to accept common JSON dialects.
+func Unmarshal(data []byte, target any, opts ...Option) error {
+	node, err := newParser(NewPeekReader(bytes.NewReader(data)), Position{1, 1}, opts...).parse()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## What

Adds two opt-in `Option`s to `Unmarshal` for parsing common JSON dialects. Both are **off by default**, so strict-JSON behaviour is unchanged and existing callers are unaffected.

- **`AllowComments()`** — permits `//` line comments and `/* ... */` block comments anywhere whitespace is allowed. Handled entirely in `parseWhitespace` (the single point every token passes through), so comments work in every position — before/after values, between object entries, inside arrays. String contents are never touched.
- **`AllowTrailingCommas()`** — permits a single trailing comma before a closing `]` or `}`.

```go
jfather.Unmarshal(data, &target, jfather.AllowComments(), jfather.AllowTrailingCommas())
```

## Why

Several widely-used JSON dialects permit these — JSONC, `tsconfig.json`, and notably **Azure ARM/Bicep deployment templates**, which officially allow comments. Real-world `azuredeploy.json` files fail strict parsing outright today. (Encountered while parsing the `Azure/azure-quickstart-templates` corpus — comments/trailing commas caused whole-template parse failures.)

## Implementation notes

- Functional options threaded through `newParser`; `Unmarshal` gains a variadic `opts ...Option` (backwards compatible).
- Comment skipping lives in `parseWhitespace`; a `/` at a whitespace boundary is only ever a comment or malformed, so a lone/invalid `/` still errors, and unterminated block comments error cleanly.
- Position metadata (line/column) is preserved across multi-line block comments.

## Tests

New `options_test.go` covers: line + block comments in all positions, comments not corrupting string contents (e.g. `http://…/*x*/`), unterminated block comment error, lone-slash error, trailing commas in objects and arrays, both options combined, metadata line-tracking after a multi-line block comment, and that **strict mode still rejects** comments and trailing commas. Full existing suite passes unchanged.