### PR TITLE
feat: optional AllowUnescapedControlChars for literal control chars in strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,9 @@ By default `Unmarshal` accepts strict [RFC 8259](https://datatracker.ietf.org/do
 
 - `AllowComments()` — allow `//` line comments and `/* ... */` block comments anywhere whitespace is permitted.
 - `AllowTrailingCommas()` — allow a single trailing comma before a closing `]` or `}`.
+- `AllowUnescapedControlChars()` — allow literal control characters (raw newlines, tabs, etc.) inside string values, instead of requiring them to be escaped. Mirrors Python's `json.loads(..., strict=False)`.
 
-These are handy for formats such as [JSONC](https://code.visualstudio.com/docs/languages/json#_json-with-comments), `tsconfig.json`, and Azure ARM/Bicep deployment templates, all of which permit comments.
+These are handy for formats such as [JSONC](https://code.visualstudio.com/docs/languages/json#_json-with-comments), `tsconfig.json`, and Azure ARM/Bicep deployment templates, all of which permit comments (and, in ARM's case, long expressions broken across multiple lines inside a single string).
 
 ```golang
 input := []byte(`{

--- a/example_test.go
+++ b/example_test.go
@@ -36,3 +36,19 @@ func ExampleAllowTrailingCommas() {
 	fmt.Println(target.Tags)
 	// Output: [a b]
 }
+
+func ExampleAllowUnescapedControlChars() {
+	// A raw newline inside the string value (an ARM-style expression
+	// broken across lines) would fail strict JSON.
+	input := []byte("{ \"expr\": \"[concat('a',\n'b')]\" }")
+
+	var target struct {
+		Expr string `json:"expr"`
+	}
+	if err := jfather.Unmarshal(input, &target, jfather.AllowUnescapedControlChars()); err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%q\n", target.Expr)
+	// Output: "[concat('a',\n'b')]"
+}

--- a/options.go
+++ b/options.go
@@ -18,3 +18,13 @@ func AllowComments() Option {
 func AllowTrailingCommas() Option {
 	return func(p *parser) { p.allowTrailingCommas = true }
 }
+
+// AllowUnescapedControlChars permits literal control characters (U+0000
+// through U+001F), such as raw newlines and tabs, to appear inside string
+// values. Standard JSON requires these to be escaped, but some producers
+// emit them literally — for example Azure ARM/Bicep templates routinely
+// break a long expression across several lines inside a single string
+// value. This mirrors Python's json.loads(..., strict=False).
+func AllowUnescapedControlChars() Option {
+	return func(p *parser) { p.allowUnescapedControls = true }
+}

--- a/options_test.go
+++ b/options_test.go
@@ -145,3 +145,43 @@ func (m *metaObject) UnmarshalJSONWithMetadata(node Node) error {
 	}
 	return nil
 }
+
+func Test_AllowUnescapedControlChars_Newline(t *testing.T) {
+	// A raw newline inside a string value — as ARM templates do when
+	// breaking a long expression across multiple lines.
+	input := []byte("{ \"expr\": \"[concat('a',\n'b')]\" }")
+	var target struct {
+		Expr string `json:"expr"`
+	}
+	require.NoError(t, Unmarshal(input, &target, AllowUnescapedControlChars()))
+	assert.Equal(t, "[concat('a',\n'b')]", target.Expr)
+}
+
+func Test_AllowUnescapedControlChars_Tab(t *testing.T) {
+	input := []byte("{ \"v\": \"a\tb\" }")
+	var target struct {
+		V string `json:"v"`
+	}
+	require.NoError(t, Unmarshal(input, &target, AllowUnescapedControlChars()))
+	assert.Equal(t, "a\tb", target.V)
+}
+
+func Test_UnescapedControlChars_RejectedByDefault(t *testing.T) {
+	input := []byte("{ \"v\": \"a\nb\" }")
+	var target struct {
+		V string `json:"v"`
+	}
+	err := Unmarshal(input, &target)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid unescaped character")
+}
+
+// A literal newline inside a string must advance the line counter so
+// metadata for subsequent tokens stays accurate.
+func Test_AllowUnescapedControlChars_TracksLineNumbers(t *testing.T) {
+	input := []byte("{\n\"a\": \"x\ny\",\n\"name\": \"here\"\n}")
+	var meta metaObject
+	require.NoError(t, Unmarshal(input, &meta, AllowUnescapedControlChars()))
+	// "a" is on line 2; its value spans a raw newline; "name" is on line 4.
+	assert.Equal(t, 4, meta.nameLine)
+}

--- a/parse.go
+++ b/parse.go
@@ -6,11 +6,12 @@ import (
 )
 
 type parser struct {
-	peeker              *PeekReader
-	position            Position
-	size                int
-	allowComments       bool
-	allowTrailingCommas bool
+	peeker                 *PeekReader
+	position               Position
+	size                   int
+	allowComments          bool
+	allowTrailingCommas    bool
+	allowUnescapedControls bool
 }
 
 func newParser(p *PeekReader, pos Position, opts ...Option) *parser {

--- a/parse_string.go
+++ b/parse_string.go
@@ -78,8 +78,15 @@ func (p *parser) parseString() (Node, error) {
 				n.end = p.position
 				return n, nil
 			default:
-				if c < 0x20 || c > 0x10FFFF {
+				if c > 0x10FFFF || (c < 0x20 && !p.allowUnescapedControls) {
 					return nil, p.makeError("invalid unescaped character '0x%X'", c)
+				}
+				// Keep line/column metadata accurate when a literal
+				// newline appears inside a string (allowed only under
+				// AllowUnescapedControlChars).
+				if c == 0x0a {
+					p.position.Column = 1
+					p.position.Line++
 				}
 				builder.WriteRune(c)
 			}


### PR DESCRIPTION
## What

Adds a third opt-in `Option`, `AllowUnescapedControlChars()`, permitting literal control characters (U+0000–U+001F) — raw newlines, tabs, etc. — inside string values. **Off by default**, so strict RFC 8259 behaviour is unchanged.

```go
jfather.Unmarshal(data, &target, jfather.AllowUnescapedControlChars())
```

Mirrors Python's `json.loads(..., strict=False)`.

## Why

Some producers emit literal control characters inside strings. Most notably, **Azure ARM/Bicep deployment templates** routinely break a long expression across several lines inside a single JSON string value:

```json
"roleAssignmentName": "[guid(resourceId('Microsoft.Compute/virtualMachines', parameters('vm')),
                             variables('role')[parameters('type')],
                             parameters('principalId'))]"
```

Strict JSON rejects the embedded newlines; Azure accepts them, and these are official quickstart templates. This option lets such documents parse.

## Implementation notes

- Single change in `parse_string.go`: the `c < 0x20` rejection is gated on the option.
- A literal newline inside a string **advances the line counter**, so position metadata (jfather's whole purpose) stays accurate for subsequent tokens.

## Tests

`options_test.go`: raw newline and tab accepted under the option; **still rejected by default**; line-number tracking across an embedded newline. Plus a runnable godoc `ExampleAllowUnescapedControlChars` and a README bullet. Full existing suite passes unchanged.