### PR TITLE
feat: enforce a maximum nesting depth to prevent stack overflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,12 @@ func main() {
 
 ## Options
 
-By default `Unmarshal` accepts strict [RFC 8259](https://datatracker.ietf.org/doc/html/rfc8259) JSON. You can pass options to accept common non-standard JSON dialects. Both options are opt-in, so the default behaviour is unchanged.
+By default `Unmarshal` accepts strict [RFC 8259](https://datatracker.ietf.org/doc/html/rfc8259) JSON. You can pass options to accept common non-standard JSON dialects. The dialect options are all opt-in, so the default behaviour is unchanged.
 
 - `AllowComments()` — allow `//` line comments and `/* ... */` block comments anywhere whitespace is permitted.
 - `AllowTrailingCommas()` — allow a single trailing comma before a closing `]` or `}`.
 - `AllowUnescapedControlChars()` — allow literal control characters (raw newlines, tabs, etc.) inside string values, instead of requiring them to be escaped. Mirrors Python's `json.loads(..., strict=False)`.
+- `MaxDepth(n)` — override the maximum nesting depth of arrays and objects, which defaults to `DefaultMaxDepth` (10,000, matching `encoding/json`). Deeper input is rejected with an error rather than parsed, protecting the parser — and any code that recursively walks the resulting tree — from stack exhaustion on maliciously deep input. The limit cannot be disabled.
 
 These are handy for formats such as [JSONC](https://code.visualstudio.com/docs/languages/json#_json-with-comments), `tsconfig.json`, and Azure ARM/Bicep deployment templates, all of which permit comments (and, in ARM's case, long expressions broken across multiple lines inside a single string).
 

--- a/options.go
+++ b/options.go
@@ -1,8 +1,8 @@
 package jfather
 
-// Option configures optional, non-standard parsing behaviour. All options
-// are off by default, so Unmarshal stays strict JSON unless a caller opts
-// in.
+// Option configures optional parsing behaviour. The dialect options
+// (AllowComments, AllowTrailingCommas, AllowUnescapedControlChars) are all
+// off by default, so Unmarshal stays strict JSON unless a caller opts in.
 type Option func(*parser)
 
 // AllowComments permits JavaScript-style comments — // to end of line and
@@ -17,6 +17,20 @@ func AllowComments() Option {
 // ']' or '}'. Standard JSON forbids it.
 func AllowTrailingCommas() Option {
 	return func(p *parser) { p.allowTrailingCommas = true }
+}
+
+// MaxDepth overrides the maximum nesting depth of arrays and objects,
+// which defaults to DefaultMaxDepth. Input nested deeper than the limit is
+// rejected with an error rather than parsed, protecting the parser — and
+// callers that recursively walk the resulting tree — from stack exhaustion
+// on maliciously deep input. Values less than 1 are ignored, leaving the
+// default in place; the limit cannot be disabled.
+func MaxDepth(depth int) Option {
+	return func(p *parser) {
+		if depth >= 1 {
+			p.maxDepth = depth
+		}
+	}
 }
 
 // AllowUnescapedControlChars permits literal control characters (U+0000

--- a/parse.go
+++ b/parse.go
@@ -5,10 +5,20 @@ import (
 	"io"
 )
 
+// DefaultMaxDepth is the maximum nesting depth of arrays and objects
+// accepted by Unmarshal unless overridden with the MaxDepth option. The
+// parser (and any code that later walks the resulting tree) recurses once
+// per nesting level, so depth must be bounded to prevent maliciously deep
+// input from overflowing the stack. The value matches encoding/json's
+// nesting limit.
+const DefaultMaxDepth = 10000
+
 type parser struct {
 	peeker                 *PeekReader
 	position               Position
 	size                   int
+	depth                  int
+	maxDepth               int
 	allowComments          bool
 	allowTrailingCommas    bool
 	allowUnescapedControls bool
@@ -18,6 +28,7 @@ func newParser(p *PeekReader, pos Position, opts ...Option) *parser {
 	parser := &parser{
 		position: pos,
 		peeker:   p,
+		maxDepth: DefaultMaxDepth,
 	}
 	for _, opt := range opts {
 		opt(parser)
@@ -94,6 +105,23 @@ func (p *parser) makeError(format string, args ...any) error {
 		p.position.Column,
 		fmt.Sprintf(format, args...),
 	)
+}
+
+// enterNesting is called on entry to parseObject/parseArray, the two
+// productions that recurse. It must run before any recursive descent so
+// over-deep input is rejected while the stack is still shallow. Callers
+// must pair it with exitNesting so depth reflects nesting, not total
+// container count.
+func (p *parser) enterNesting() error {
+	p.depth++
+	if p.depth > p.maxDepth {
+		return p.makeError("maximum nesting depth of %d exceeded", p.maxDepth)
+	}
+	return nil
+}
+
+func (p *parser) exitNesting() {
+	p.depth--
 }
 
 func (p *parser) newNode(k Kind) *node {

--- a/parse_array.go
+++ b/parse_array.go
@@ -1,6 +1,11 @@
 package jfather
 
 func (p *parser) parseArray() (Node, error) {
+	if err := p.enterNesting(); err != nil {
+		return nil, err
+	}
+	defer p.exitNesting()
+
 	n := p.newNode(KindArray)
 
 	c, err := p.next()

--- a/parse_depth_test.go
+++ b/parse_depth_test.go
@@ -1,0 +1,82 @@
+package jfather
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// deepArrays returns a valid JSON document of n nested arrays: [[[...]]].
+func deepArrays(n int) []byte {
+	return []byte(strings.Repeat("[", n) + strings.Repeat("]", n))
+}
+
+// deepObjects returns a valid JSON document of n nested objects:
+// {"a":{"a":...{}...}}.
+func deepObjects(n int) []byte {
+	var sb strings.Builder
+	for i := 0; i < n-1; i++ {
+		sb.WriteString(`{"a":`)
+	}
+	sb.WriteString("{}")
+	sb.WriteString(strings.Repeat("}", n-1))
+	return []byte(sb.String())
+}
+
+func Test_MaxDepth_DefaultRejectsPathologicalInput(t *testing.T) {
+	// The original crash repro: megabytes of unclosed '[' used to overflow
+	// the stack and kill the process with an uncatchable fatal error. It
+	// must now fail fast with a regular error.
+	example := []byte(strings.Repeat("[", 3_000_000))
+
+	var target any
+	err := Unmarshal(example, &target)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "maximum nesting depth")
+}
+
+func Test_MaxDepth_DefaultAllowsDeepButBoundedInput(t *testing.T) {
+	var target any
+	require.NoError(t, Unmarshal(deepArrays(DefaultMaxDepth), &target))
+
+	err := Unmarshal(deepArrays(DefaultMaxDepth+1), &target)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "maximum nesting depth")
+}
+
+func Test_MaxDepth_OptionOverridesDefault(t *testing.T) {
+	var target any
+	require.NoError(t, Unmarshal(deepArrays(5), &target, MaxDepth(5)))
+	require.Error(t, Unmarshal(deepArrays(6), &target, MaxDepth(5)))
+}
+
+func Test_MaxDepth_CountsObjectsToo(t *testing.T) {
+	var target any
+	require.NoError(t, Unmarshal(deepObjects(5), &target, MaxDepth(5)))
+	require.Error(t, Unmarshal(deepObjects(6), &target, MaxDepth(5)))
+}
+
+func Test_MaxDepth_MixedNesting(t *testing.T) {
+	example := []byte(`{"a":[{"b":[1]}]}`)
+
+	var target any
+	require.NoError(t, Unmarshal(example, &target, MaxDepth(4)))
+	require.Error(t, Unmarshal(example, &target, MaxDepth(3)))
+}
+
+func Test_MaxDepth_SiblingsDoNotAccumulate(t *testing.T) {
+	// Depth tracks nesting, not the total number of containers, so many
+	// shallow siblings must parse fine under a tight limit.
+	example := []byte(`[[1],[2],[3],[4],{"a":5}]`)
+
+	var target any
+	require.NoError(t, Unmarshal(example, &target, MaxDepth(2)))
+}
+
+func Test_MaxDepth_InvalidValuesKeepDefault(t *testing.T) {
+	var target any
+	require.NoError(t, Unmarshal(deepArrays(10), &target, MaxDepth(0)))
+	require.NoError(t, Unmarshal(deepArrays(10), &target, MaxDepth(-1)))
+}

--- a/parse_object.go
+++ b/parse_object.go
@@ -2,6 +2,11 @@ package jfather
 
 func (p *parser) parseObject() (Node, error) {
 
+	if err := p.enterNesting(); err != nil {
+		return nil, err
+	}
+	defer p.exitNesting()
+
 	n := p.newNode(KindObject)
 	c, err := p.next()
 	if err != nil {


### PR DESCRIPTION
Deeply nested input (e.g. megabytes of `[`) previously recursed unbounded and crashed the process with an uncatchable `fatal error: stack overflow` — a DoS vector for anyone parsing untrusted JSON.

Parsing now fails with a regular error beyond a nesting depth limit, defaulting to 10,000 (matching `encoding/json`) and tunable via a new `MaxDepth` option. The limit cannot be disabled. Bounding the parse depth also bounds any recursion callers perform over the resulting node tree.